### PR TITLE
Support Repeating Query Parameters

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -64,12 +64,15 @@ let clean = "clean", fun () ->
     |> Shell.cleanDirs 
 
 let slnPath = "./src/FsHttp.sln"
-
 let build = "build", fun () ->
     Shell.ExecSuccess ("dotnet", $"build {slnPath}")
 
+
+let CsTestProjectPath = "./src/Test.CSharp/Test.CSharp.csproj"
+let FsharpTestProjectPath = "./src/Tests/Tests.fsproj"
 let test = "test", fun () ->
-    Shell.ExecSuccess ("dotnet", $"test {slnPath}")
+    Shell.ExecSuccess ("dotnet", $"test {FsharpTestProjectPath}")
+    Shell.ExecSuccess ("dotnet", $"test {CsTestProjectPath}")
 
 let pack = "pack", fun () ->
     !! "src/**/FsHttp*.fsproj"

--- a/src/FsHttp/Domain.fs
+++ b/src/FsHttp/Domain.fs
@@ -62,7 +62,7 @@ type PrintHintTransformer = PrintHint -> PrintHint
 
 type FsHttpUrl = {
     address: string
-    additionalQueryParams: Map<string, obj>
+    additionalQueryParams: List<string * obj>
 }
 
 type Header = {

--- a/src/FsHttp/Dsl.fs
+++ b/src/FsHttp/Dsl.fs
@@ -32,7 +32,7 @@ module Http =
             header = {
                 url = {
                     address = formattedUrl
-                    additionalQueryParams = Map.empty
+                    additionalQueryParams = []
                 }
                 method = HttpMethod(method)
                 headers = Map.empty
@@ -80,9 +80,8 @@ module Header =
     /// Adds a set of query parameters to the URL
     let query (queryParams: (string * obj) list) (context: HeaderContext) = {
         context with
-            header = { context.header with url = { context.header.url with additionalQueryParams = queryParams |> Map.ofList } }
+            header = { context.header with url = { context.header.url with additionalQueryParams = queryParams } }
     }
-
 
     /// Content-Types that are acceptable for the response
     let accept (contentType: string) (context: HeaderContext) = header "Accept" contentType context

--- a/src/FsHttp/Helper.fs
+++ b/src/FsHttp/Helper.fs
@@ -222,7 +222,7 @@ module FsHttpUrlExtensions =
 
             let queryParamsString =
                 this.additionalQueryParams
-                |> Seq.map (fun kvp -> $"""{kvp.Key}={Uri.EscapeDataString $"{kvp.Value}"}""")
+                |> Seq.map (fun (k, v) -> $"""{k}={Uri.EscapeDataString $"{v}"}""")
                 |> String.concat "&"
 
             uri.Query <-


### PR DESCRIPTION
additionalQueryParams has recently changed from List<string, string> to Map<string, obj>

Some systems are designed to accept repeating query parameters. Map effectively removes the duplicates which results in unexpected results after upgrading FsHttp in existing codebases.

Pretty straightforward to change it back to List<string, string> or List<string, obj>.