### PR TITLE
update fsharp.formatting.commandtool 11.5.1 to fsdocs-tool 19.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fsharp.formatting.commandtool": {
-      "version": "11.5.1",
+    "fsdocs-tool": {
+      "version": "19.0.0",
       "commands": [
         "fsdocs"
       ]


### PR DESCRIPTION
I'm often somewhat baffled by fsharp.formatting but this update makes the "License", "Release Notes", "Source Repository" and "Namespace" links in the navbar work for me. The hope is, that also fixes the links of the github.io docs.