### PR TITLE
obj -> string for FsHttpUrl.additionalQueryParams

### DIFF
--- a/docs/URLs_and_Query_Params.html
+++ b/docs/URLs_and_Query_Params.html
@@ -145,7 +145,7 @@
 <pre class="fssnip highlighted"><code lang="fsharp"><span onmouseout="hideTip(event, 'fs2', 6)" onmouseover="showTip(event, 'fs2', 6)" class="k">http</span> <span class="pn">{</span>
     <span onmouseout="hideTip(event, 'fs3', 7)" onmouseover="showTip(event, 'fs3', 7)" class="k">GET</span> <span class="s">&quot;https://mysite&quot;</span>
     <span onmouseout="hideTip(event, 'fs6', 8)" onmouseover="showTip(event, 'fs6', 8)" class="k">query</span> <span class="pn">[</span>
-        <span class="s">&quot;page&quot;</span><span class="pn">,</span> <span class="n">2</span>
+        <span class="s">&quot;page&quot;</span><span class="pn">,</span> <span class="s">&quot;2&quot;</span>
         <span class="s">&quot;name&quot;</span><span class="pn">,</span> <span class="s">&quot;Hans&quot;</span>
     <span class="pn">]</span>
 <span class="pn">}</span>
@@ -171,7 +171,7 @@ from FsHttp<br /><br />--------------------<br />type Request =
 <div class="fsdocs-tip" id="fs5">val send: context: IToRequest -&gt; Response<br /><em>&lt;summary&gt;
  Sends a request synchronously.
 &lt;/summary&gt;</em></div>
-<div class="fsdocs-tip" id="fs6">custom operation: query ((string * obj) list)
+<div class="fsdocs-tip" id="fs6">custom operation: query ((string * string) list)
 
 Calls IRequestContext.Query<br /><em>&lt;summary&gt;
  Append query params

--- a/src/FsHttp/Domain.fs
+++ b/src/FsHttp/Domain.fs
@@ -63,7 +63,7 @@ type PrintHintTransformer = PrintHint -> PrintHint
 
 type FsHttpUrl = {
     address: string
-    additionalQueryParams: List<string * obj>
+    additionalQueryParams: List<string * string>
 }
 
 type Header = {

--- a/src/FsHttp/Dsl.fs
+++ b/src/FsHttp/Dsl.fs
@@ -78,7 +78,7 @@ module Header =
     let header name value (context: HeaderContext) = headers [ name, value ] context
 
     /// Adds a set of query parameters to the URL
-    let query (queryParams: (string * obj) list) (context: HeaderContext) = {
+    let query (queryParams: (string * string) list) (context: HeaderContext) = {
         context with
             header = { context.header with url = { context.header.url with additionalQueryParams = queryParams } }
     }

--- a/src/docs/URLs_and_Query_Params.fsx
+++ b/src/docs/URLs_and_Query_Params.fsx
@@ -38,7 +38,7 @@ It's also possible to specify query params in a list:
 http {
     GET "https://mysite"
     query [
-        "page", 2
+        "page", "2"
         "name", "Hans"
     ]
 }


### PR DESCRIPTION
This PR resolves [issue 102](https://github.com/fsprojects/FsHttp/issues/102) based on the following assumptions:

- A preferred implementation would use `(string * string) list` instead of `(string * obj) list` for both the `query` and `formUrlEncoded` functions.
- Changing the type of `FsHttpUrl.additionalQueryParams` does not result in tests failing. This includes the test cases in `src/Tests/UrlsAndQuery.fs`. The tests pass `string * string` instead of `string * obj`
- Asking users to perform value formatting for the call decouples the 'stringification' for use with FsHttp from any other uses outside the bounds of FsHttp.