### PR TITLE
Do ordinal string comparisons

### DIFF
--- a/fiddle/scratch.fsx
+++ b/fiddle/scratch.fsx
@@ -279,7 +279,7 @@ open System.Reflection
 
 let isInteractive =
     let asm = Assembly.GetExecutingAssembly()
-    asm.IsDynamic && asm.GetName().Name.StartsWith("FSI-ASSEMBLY")
+    asm.IsDynamic && asm.GetName().Name.StartsWith("FSI-ASSEMBLY", StringComparison.Ordinal)
 
 AppDomain.CurrentDomain.GetAssemblies()
 |> Array.tryFind (fun x -> x.GetName().Name = "FSharp.Compiler.Interactive.Settings")

--- a/src/FsHttp/Dsl.fs
+++ b/src/FsHttp/Dsl.fs
@@ -25,7 +25,7 @@ module Http =
         let formattedUrl =
             url.Split([| '\n' |], StringSplitOptions.RemoveEmptyEntries)
             |> Seq.map (fun x -> x.Trim().Replace("\r", ""))
-            |> Seq.filter (fun x -> not (x.StartsWith("//")))
+            |> Seq.filter (fun x -> not (x.StartsWith("//", StringComparison.Ordinal)))
             |> Seq.reduce (+)
 
         {

--- a/src/FsHttp/FsiInit.fs
+++ b/src/FsHttp/FsiInit.fs
@@ -24,7 +24,9 @@ let doInit () =
         let isInteractive =
             // This hack is indeed one (see https://fsharp.github.io/fsharp-compiler-docs/fsi-emit.html)
             AppDomain.CurrentDomain.GetAssemblies()
-            |> Array.exists (fun asm -> (*asm.IsDynamic &&*) asm.GetName().Name.StartsWith(fsiAssemblyName))
+            |> Array.exists (fun asm -> (*asm.IsDynamic &&*)
+                asm.GetName().Name.StartsWith(fsiAssemblyName, StringComparison.Ordinal)
+            )
 
         state <-
             try

--- a/src/Tests/Basic.fs
+++ b/src/Tests/Basic.fs
@@ -96,7 +96,7 @@ let ``Smoke test for headers`` () =
         >=> request (fun r ->
             let headers =
                 r.headers
-                |> List.filter (fun (k, _) -> k.StartsWith(headerPrefix, StringComparison.InvariantCultureIgnoreCase))
+                |> List.filter (fun (k, _) -> k.StartsWith(headerPrefix, StringComparison.OrdinalIgnoreCase))
 
             headersToString headers |> OK
         )

--- a/src/Tests/Misc.fs
+++ b/src/Tests/Misc.fs
@@ -66,7 +66,7 @@ let ``Custom Headers`` () =
         GET
         >=> request (fun r ->
             r.headers
-            |> List.filter (fun (k, _) -> k.StartsWith(headerPrefix, StringComparison.InvariantCultureIgnoreCase))
+            |> List.filter (fun (k, _) -> k.StartsWith(headerPrefix, StringComparison.OrdinalIgnoreCase))
             |> headersToString
             |> OK
         )


### PR DESCRIPTION
Using Ordinal is both faster and more correct as our intent is to do symbolic compares.
See https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings for the full story.