### PR TITLE
Build solution

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -22,7 +22,7 @@ jobs:
           dotnet-version: 7.x
 
       - name: Build solution
-        run: dotnet build
+        run: dotnet build -c Release
 
       - name: Build docu
         shell: pwsh

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           dotnet-version: 7.x
 
+      - name: Build solution
+        run: dotnet build
+
       - name: Build docu
         shell: pwsh
         run: ./docu.ps1


### PR DESCRIPTION
In https://github.com/fsprojects/FsHttp/pull/145, `--strict` was added.
Because the solution isn't built, the API docs cannot be generated and in `--strict` that will fail the docs build. Which means the new docs didn't get published.