### PR TITLE
fix(deps): Reduce FSharp.Core dependency back to 5.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,9 @@
     <FsDocsReleaseNotesLink>https://www.nuget.org/packages/FsHttp#release-body-tab</FsDocsReleaseNotesLink>
 
     <PackageReleaseNotes>
+      v14.4.2
+      - Reduced FSharp.Core version dependency back down to 5.0.0
+      
       v14.4.1
       - Fixed missing explicit dependency on FSharp.Core
 

--- a/src/FsHttp.FSharpData/FsHttp.FSharpData.fsproj
+++ b/src/FsHttp.FSharpData/FsHttp.FSharpData.fsproj
@@ -16,7 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="6.3.0" />
-    <PackageReference Include="FSharp.Core" Version="8.0.100" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />

--- a/src/FsHttp/FsHttp.fsproj
+++ b/src/FsHttp/FsHttp.fsproj
@@ -38,11 +38,13 @@
     <None Include="..\..\docs\img\logo_small.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <!-- NOTE: intentionally depend on a minimal version of FSharp.Core as the package previously did 
+    <!-- NOTE: intentionally depend on a minimal version of FSharp.Core as the package previously did prior to V13
                see https://github.com/fsprojects/FsHttp/issues/183 -->
+    <!-- NOTE: releases 13-14.4.0 did not include a nuspec declaration of their dependency on FSharp.Core V8.0.100
+               so tools like Paket will gravitate toward those broken versions if we make the version constraint more restrictive -->
     <!-- ExcludeAssets is a workaround for malformed FSharp.Core packages https://github.com/dotnet/fsharp/issues/12706 via https://github.com/fsprojects/Paket/issues/4149-->
     <!-- Removal triggers issues in dotnet publish, e.g. for Lambda projects -->
     <!-- Also avoids Rider search finding stuff in FSharp.Core.xml -->
-    <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
+    <PackageReference Include="FSharp.Core" Version="5.0.0" ExcludeAssets="contentfiles" />
   </ItemGroup>
 </Project>

--- a/src/FsHttp/FsHttp.fsproj
+++ b/src/FsHttp/FsHttp.fsproj
@@ -38,6 +38,11 @@
     <None Include="..\..\docs\img\logo_small.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="8.0.100" />
+    <!-- NOTE: intentionally depend on a minimal version of FSharp.Core as the package previously did 
+               see https://github.com/fsprojects/FsHttp/issues/183 -->
+    <!-- ExcludeAssets is a workaround for malformed FSharp.Core packages https://github.com/dotnet/fsharp/issues/12706 via https://github.com/fsprojects/Paket/issues/4149-->
+    <!-- Removal triggers issues in dotnet publish, e.g. for Lambda projects -->
+    <!-- Also avoids Rider search finding stuff in FSharp.Core.xml -->
+    <PackageReference Include="FSharp.Core" Version="6.0.7" ExcludeAssets="contentfiles" />
   </ItemGroup>
 </Project>

--- a/src/Test.CSharp/Test.CSharp.csproj
+++ b/src/Test.CSharp/Test.CSharp.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Tests.fsproj
+++ b/src/Tests/Tests.fsproj
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-    <OutputType>Library</OutputType>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
FsHttp package versions 13-14.4.0 omitted to state their dependency on `FSharp.Core`

This means that anyone who is using a `FSharp.Core` prior to `8.0.100` (which v `14.4.1` correctly declares its dependence on) winds up (if they use a tool that depends on `nuspec` dependency declarations (such as `paket`, but also Rider etc):
- getting `14.4.0` (technically correct, not a `paket` bug)
- (on a machine that is running a `net6.0` runtime) getting surprised at runtime with a:
   ```
   System.IO.FileLoadException: Could not load file or assembly 'FSharp.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
   The located assembly's manifest definition does not match the assembly reference. (0x80131040)
   File name: 'FSharp.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   ```

This PR rolls all the way back to only demanding V5, like the older versions did

resolves #183 