### PR TITLE
fix(deps): Remove redundant TFM-specific builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,10 @@
     <FsDocsReleaseNotesLink>https://www.nuget.org/packages/FsHttp#release-body-tab</FsDocsReleaseNotesLink>
 
     <PackageReleaseNotes>
+      v14.4.2
+      - Reduced FSharp.Core version dependency back down to 5.0.0
+      - Removed net7.0, net8.0 TFM-specific builds
+
       v14.4.1
       - Fixed missing explicit dependency on FSharp.Core
 

--- a/src/FsHttp.FSharpData/FsHttp.FSharpData.fsproj
+++ b/src/FsHttp.FSharpData/FsHttp.FSharpData.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Configurations>Debug;Release</Configurations>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/src/FsHttp.NewtonsoftJson/FsHttp.NewtonsoftJson.fsproj
+++ b/src/FsHttp.NewtonsoftJson/FsHttp.NewtonsoftJson.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Configurations>Debug;Release</Configurations>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/src/FsHttp/FsHttp.fsproj
+++ b/src/FsHttp/FsHttp.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Configurations>Debug;Release</Configurations>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>


### PR DESCRIPTION
potential follow-up to #184
See https://github.com/serilog/serilog/issues/1970 for lots of reasoning, but the TL;DR is:

In the general case, a library should depend on the minimum TFM that it can be implemented in terms of. For many libs, thats `netstandard2.0`, and supporting that is great when it's possible.

- In the `netstandard2.1` - `net5.0` timeframe, there are various confusions, and ultimately there's not benefit to specifically targeting them or thinking about them

- `net6.0` brings significant available API surface and removes the need for complex conditional dependencies

Adding TFM-specific builds for stuff later than `net6.0` on the other hand brings little concrete benefit. i.e.
- builds take longer
- nupkg is larger
- more analysis required to figure out the TFM flavor being used in a given runtime scenario
- in very rare cases, if the compiler knows that the TFM is recent, it can lean on newer intrinsics, which can confer a size or speed advantage
- people see that net6.0, net7.0 and net8.0 are supported but agonize needlessly about whether `net9.0` is "supported"